### PR TITLE
[codex] standardize readme license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,6 @@ npm run lint
 
 Pull requests are welcome for improvements to UI, content, and accessibility.
 
-## Contact
-- Email: `jayakuma006@mymail.sim.edu.sg`
-- LinkedIn: [https://www.linkedin.com/in/akileshjayakumar/](https://www.linkedin.com/in/akileshjayakumar/)
-- GitHub: [https://github.com/akileshjayakumar](https://github.com/akileshjayakumar)
-
 ## License
-MIT
+Licensed under the `MIT` license. See [LICENSE](./LICENSE) for full text.
 


### PR DESCRIPTION
## Summary
This PR updates the README to align with the standardized README-builder guidance: no contact section by default and SPDX-based license wording with a `LICENSE` file link.

## Problem
The README still contained a personal contact section and used a minimal `MIT` line for licensing. That no longer matches the repository's updated README skill conventions.

## Root Cause
The README was authored before the latest README-builder policy update that requires concise, scan-first docs and a standardized license section format.

## Fix
- Removed the `Contact` section and personal contact details from `README.md`.
- Updated the `License` section to the standardized format:
  - `Licensed under the \`MIT\` license. See [LICENSE](./LICENSE) for full text.`

## User Impact
The README is now cleaner and easier to scan, while following consistent documentation policy across projects.

## Validation
- `npm run lint` (passes with one existing warning in `src/components/Skills.tsx` about `<img>` usage)
